### PR TITLE
* Fixes test to match new BTDocumentParams

### DIFF
--- a/onshape_test/api_app_element_test.go
+++ b/onshape_test/api_app_element_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/onshape-public/go-client/onshape"
+	"github.com/onshape-public/go-client/onshape_test/testhelper"
 	"github.com/stretchr/testify/require"
 )
 
@@ -36,7 +37,7 @@ func TestAppElementAPI(t *testing.T) {
 			ApiService: Context()["client"].(*onshape.APIClient).DocumentApi,
 		}.BTDocumentParams(onshape.BTDocumentParams{
 			Name:        "test-doc",
-			Description: "This is a test document",
+			Description: &testhelper.DocumentDescription,
 			IsPublic:    Ptr(false),
 		}),
 		Expect: NoAPIError(),
@@ -133,7 +134,7 @@ func TestTransactionAppElementAPI(t *testing.T) {
 			ApiService: Context()["client"].(*onshape.APIClient).DocumentApi,
 		}.BTDocumentParams(onshape.BTDocumentParams{
 			Name:        "test-doc",
-			Description: "This is a test document",
+			Description: &testhelper.DocumentDescription,
 			IsPublic:    Ptr(false),
 		}),
 		Expect: NoAPIError(),

--- a/onshape_test/api_document_test.go
+++ b/onshape_test/api_document_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/onshape-public/go-client/onshape"
+	"github.com/onshape-public/go-client/onshape_test/testhelper"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/slices"
 )
@@ -21,7 +22,7 @@ func TestDocumentAPI(t *testing.T) {
 		"docPublic": false,
 		"bTDocumentParams": &onshape.BTDocumentParams{
 			Name:        "test-doc",
-			Description: "This is a test document",
+			Description: &testhelper.DocumentDescription,
 			IsPublic:    Ptr(false),
 		},
 		"wm":  "w",
@@ -57,7 +58,7 @@ func TestDocumentAPI(t *testing.T) {
 			require.Equal(Tester(), r.GetId(), Context()["did"])
 			require.Equal(Tester(), r.GetName(), *Context()["label"].(*string))
 			require.Equal(Tester(), r.GetPublic(), Context()["docPublic"])
-			require.Equal(Tester(), r.GetDescription(), Context()["bTDocumentParams"].(*onshape.BTDocumentParams).Description)
+			require.Equal(Tester(), r.GetDescription(), *Context()["bTDocumentParams"].(*onshape.BTDocumentParams).Description)
 			require.True(Tester(), r.HasDefaultWorkspace())
 		}),
 	}.Execute()

--- a/onshape_test/api_documents_test.go
+++ b/onshape_test/api_documents_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/onshape-public/go-client/onshape"
+	"github.com/onshape-public/go-client/onshape_test/testhelper"
 	"github.com/stretchr/testify/require"
 )
 
@@ -51,7 +52,8 @@ func TestCreateAndGetDocument(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			docParams := onshape.NewBTDocumentParams("Document description", "Test document")
+			docParams := onshape.NewBTDocumentParams("Document description")
+			docParams.Description = &testhelper.DocumentDescription
 			docParams.SetName(tt.args.docName)
 			docParams.SetIsPublic(false)
 

--- a/onshape_test/api_element_test.go
+++ b/onshape_test/api_element_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/onshape-public/go-client/onshape"
+	"github.com/onshape-public/go-client/onshape_test/testhelper"
 )
 
 func TestElementAPI(t *testing.T) {
@@ -18,7 +19,7 @@ func TestElementAPI(t *testing.T) {
 			ApiService: Context()["client"].(*onshape.APIClient).DocumentApi,
 		}.BTDocumentParams(onshape.BTDocumentParams{
 			Name:        "test-doc",
-			Description: "This is a test document",
+			Description: &testhelper.DocumentDescription,
 			IsPublic:    Ptr(false),
 		}),
 		Expect: NoAPIError(),

--- a/onshape_test/api_event_test.go
+++ b/onshape_test/api_event_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/onshape-public/go-client/onshape"
+	"github.com/onshape-public/go-client/onshape_test/testhelper"
 	"github.com/stretchr/testify/require"
 )
 
@@ -20,7 +21,7 @@ func TestEventAPI(t *testing.T) {
 			ApiService: Context()["client"].(*onshape.APIClient).DocumentApi,
 		}.BTDocumentParams(onshape.BTDocumentParams{
 			Name:        "test-doc",
-			Description: "This is a test document",
+			Description: &testhelper.DocumentDescription,
 			IsPublic:    Ptr(false),
 		}),
 		Expect: NoAPIError(),

--- a/onshape_test/api_metadata_test.go
+++ b/onshape_test/api_metadata_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/onshape-public/go-client/onshape"
+	"github.com/onshape-public/go-client/onshape_test/testhelper"
 	"github.com/stretchr/testify/require"
 )
 
@@ -45,7 +46,7 @@ func TestMetadataAPI(t *testing.T) {
 			ApiService: Context()["client"].(*onshape.APIClient).DocumentApi,
 		}.BTDocumentParams(onshape.BTDocumentParams{
 			Name:        "test-doc",
-			Description: "This is a test document",
+			Description: &testhelper.DocumentDescription,
 			IsPublic:    Ptr(false),
 		}),
 		Expect: NoAPIError(),

--- a/onshape_test/testhelper/test_helper.go
+++ b/onshape_test/testhelper/test_helper.go
@@ -10,10 +10,13 @@ import (
 	"github.com/onshape-public/go-client/onshape"
 )
 
+var DocumentDescription = "This is a test document"
+
 // SetupDocument creates an Onshape document
 func SetupDocument(ctx context.Context, client *onshape.APIClient, name string) (string, string,
 	func() (respStatus int, err error)) {
-	docParams := onshape.NewBTDocumentParams("Document description", "Test document")
+	docParams := onshape.NewBTDocumentParams("Test document")
+	docParams.Description = &DocumentDescription
 	docParams.SetName(name)
 	//docParams.SetIsPublic(true)
 	//create document


### PR DESCRIPTION
There was a breaking change around documents. This MR fixes the test for the new definition of BTDocumentParams.