### PR TITLE
Updates go version to 1.24

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/onshape-public/go-client
 
-go 1.23.0
+go 1.24
 
 require (
 	github.com/google/uuid v1.3.0

--- a/onshape_test_gen/go.mod
+++ b/onshape_test_gen/go.mod
@@ -1,6 +1,6 @@
 module github.com/onshape-public/go-client/test-gen
 
-go 1.18
+go 1.24
 
 replace github.com/onshape-public/go-client v1.6.3 => ./..
 


### PR DESCRIPTION
The step to update the go modules is failing because one of the new module requires go version 24. This PR updates the go version to fix this.